### PR TITLE
Added the grype ignore config to all scanning jobs

### DIFF
--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -21,5 +21,5 @@ TAG=$(cat image-source/tag)
 
 #scan
 cp grype-scan-ignore-config ~/grype.yaml
-grype ${IMAGE}:${TAG} -q -o cyclonedx --file output/${FILE}.xml
+grype ${IMAGE}:${TAG} -c ~/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,6 +21,8 @@ jobs:
       resource: ecr-concourse-task
     - get: scan-source
       trigger: false
+    - get: grype-scan-ignore-config
+      trigger: true
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -51,6 +53,8 @@ jobs:
       resource: ecr-s3-resource-simple
     - get: scan-source
       trigger: false
+    - get: grype-scan-ignore-config
+      trigger: true
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -81,6 +85,8 @@ jobs:
       resource: ecr-sql-clients
     - get: scan-source
       trigger: false
+    - get: grype-scan-ignore-config
+      trigger: true
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -111,6 +117,8 @@ jobs:
       trigger: true
     - get: scan-source
       trigger: false
+    - get: grype-scan-ignore-config
+      trigger: true
   - task: scan
     file: scan-source/ci/scan-container.yml
     params:
@@ -199,6 +207,8 @@ jobs:
       trigger: true
     - get: scan-source
       trigger: false
+    - get: grype-scan-ignore-config
+      trigger: true
   - task: scan
     file: scan-source/ci/scan-container.yml
     params:
@@ -242,6 +252,8 @@ jobs:
       trigger: true
     - get: scan-source
       trigger: false
+    - get: grype-scan-ignore-config
+      trigger: true
   - task: scan
     file: scan-source/ci/scan-container.yml
     params:

--- a/ci/scan-container.sh
+++ b/ci/scan-container.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 ls grype-scan-ignore-config
 cp grype-scan-ignore-config/grype.yaml ~/grype.yaml
-grype ${IMAGE} -q -o json --file cves/output.json
-grype ${IMAGE} -q -o table --file table.txt
+grype ${IMAGE} -c ~/grype.yaml -q -o json --file cves/output.json
+grype ${IMAGE} -c ~/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 

--- a/ci/scan-ecr-container.sh
+++ b/ci/scan-ecr-container.sh
@@ -19,8 +19,8 @@ printf "${CONFIG}" > ~/.docker/config.json
 
 #scan
 cp grype-scan-ignore-config ~/grype.yaml
-grype ${IMAGE} -q -o json --file cves/output.json
-grype ${IMAGE} -q -o table --file table.txt
+grype ${IMAGE} -c ~/grype.yaml -q -o json --file cves/output.json
+grype ${IMAGE} -c ~/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 


### PR DESCRIPTION
	modified:   ci/pipeline.yml
        modified:   ci/conmon-scan-ecr-container.sh
        modified:   ci/scan-container.sh
        modified:   ci/scan-ecr-container.sh
## Changes proposed in this pull request:

- Added the grype ignore config to all scanning jobs in ci/pipeline.yml
- Modified the grype configuration to point to the grype.yaml file during the scanning task.
- 

## Security considerations

There are no security considerations related to this request.