### PR TITLE
Reverted grype config ignore for the conmon pipeline script.

### DIFF
--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -21,5 +21,5 @@ TAG=$(cat image-source/tag)
 
 #scan
 cp grype-scan-ignore-config ~/grype.yaml
-grype ${IMAGE}:${TAG} -c ~/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
+grype ${IMAGE}:${TAG} -q -o cyclonedx --file output/${FILE}.xml
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,8 +21,6 @@ jobs:
       resource: ecr-concourse-task
     - get: scan-source
       trigger: false
-    - get: grype-scan-ignore-config
-      trigger: true
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:


### PR DESCRIPTION
	modified:   ci/conmon-scan-ecr-container.sh
	modified:   ci/pipeline.yml

## Changes proposed in this pull request:

- Reversed the grype ignore config for the conmon pipeline.
- 	modified:   ci/conmon-scan-ecr-container.sh
	modified:   ci/pipeline.yml
- 
- 

## Security considerations

There are no security considerations.