### PR TITLE
Modified grype config for the conmon pipeline script and removed it f…

### DIFF
--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -21,5 +21,5 @@ TAG=$(cat image-source/tag)
 
 #scan
 cp grype-scan-ignore-config ~/grype.yaml
-grype ${IMAGE}:${TAG} -c . ~/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
+grype ${IMAGE}:${TAG} -c grype-scan-ignore-config/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -403,8 +403,6 @@ jobs:
   - get: scan-source
     trigger: false
     passed: [list-tags-concourse-task]
-  - get: grype-scan-ignore-config
-    trigger: true
   - get: gsa-concourse-task
     params:
       format: oci
@@ -431,8 +429,6 @@ jobs:
   - get: scan-source
     trigger: false  
     passed: [list-tags-s3-resource-simple]
-  - get: grype-scan-ignore-config
-    trigger: true
   - get: gsa-s3-resource-simple
     params:
       format: oci
@@ -459,8 +455,6 @@ jobs:
   - get: scan-source
     trigger: false
     passed: [list-tags-oracle-client]
-  - get: grype-scan-ignore-config
-    trigger: true
   - get: gsa-oracle-client
     params:
       format: oci
@@ -487,8 +481,6 @@ jobs:
   - get: scan-source
     trigger: false
     passed: [list-tags-sql-clients]
-  - get: grype-scan-ignore-config
-    trigger: true
   - get: gsa-sql-clients
     params:
       format: oci


### PR DESCRIPTION
## Changes proposed in this pull request:

- Modified entry for grype ignore config for the conmon scanning pipeline script and removed it for the tag listings 
- modified:   ci/conmon-scan-ecr-container.sh     modified:   ci/pipeline.yml 
- 
- 

## Security considerations

There are no security considerations for this request.