### PR TITLE
Modify grype ignore config input file path for the scan tasks

### DIFF
--- a/ci/scan-container.sh
+++ b/ci/scan-container.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 ls grype-scan-ignore-config
 cp grype-scan-ignore-config/grype.yaml ~/grype.yaml
-grype ${IMAGE} -c ~/grype.yaml -q -o json --file cves/output.json
-grype ${IMAGE} -c ~/grype.yaml -q -o table --file table.txt
+grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o json --file cves/output.json
+grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 

--- a/ci/scan-ecr-container.sh
+++ b/ci/scan-ecr-container.sh
@@ -19,8 +19,8 @@ printf "${CONFIG}" > ~/.docker/config.json
 
 #scan
 cp grype-scan-ignore-config ~/grype.yaml
-grype ${IMAGE} -c ~/grype.yaml -q -o json --file cves/output.json
-grype ${IMAGE} -c ~/grype.yaml -q -o table --file table.txt
+grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o json --file cves/output.json
+grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Modify grype ignore config input file path for the scan tasks
        modified:   ci/scan-container.sh
        modified:   ci/scan-ecr-container.sh
- 
- 

## Security considerations

There are no security considerations for this request.