### PR TITLE
update pipeline triggers, fix container reference, fix cp warning

### DIFF
--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -20,6 +20,6 @@ printf "${CONFIG}" > ~/.docker/config.json
 TAG=$(cat image-source/tag)
 
 #scan
-cp grype-scan-ignore-config ~/grype.yaml
+cp grype-scan-ignore-config/grype.yaml ~/grype.yaml
 grype ${IMAGE}:${TAG} -c grype-scan-ignore-config/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -74,7 +74,7 @@ jobs:
     - get: scan-source
       trigger: false
     - get: grype-scan-ignore-config
-      trigger: true
+      trigger: false
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -106,7 +106,7 @@ jobs:
     - get: scan-source
       trigger: false
     - get: grype-scan-ignore-config
-      trigger: true
+      trigger: false
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -138,7 +138,7 @@ jobs:
     - get: scan-source
       trigger: false
     - get: grype-scan-ignore-config
-      trigger: true
+      trigger: false
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:

--- a/terraform/terraform-apply.yml
+++ b/terraform/terraform-apply.yml
@@ -1,9 +1,13 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: 18fgsa/concourse-task
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: harden-concourse-task
+    aws_region: us-gov-west-1
+    semver_constraint: ">= 1.0.0"
 
 inputs:
 - name: terraform-templates


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix pipelines so that conmon jobs don't trigger on ignore file update
- Fix conmon scan script 'cp -r' warning that shows up in ci
- Update terraform job to use hardened container

## Security considerations

Hardened containers are more secure
