### PR TITLE
feat: Pages repo add 7 day untagged image expiration

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -33,3 +33,27 @@ resource "aws_ecr_repository" "pages_repository" {
   image_tag_mutability = "MUTABLE"
 }
 
+resource "aws_ecr_lifecycle_policy" "expire_untagged_images" {
+  count = length(var.pages_repositories)
+
+  repository = var.pages_repositories[count.index]
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire untagged images older than 7 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 7
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}


### PR DESCRIPTION
Since Pages uses mutable image tags, updated repository images untag their older iterations so this adds an ECR lifecycle policy to clean up the untagged images.

## Changes proposed in this pull request:

- Remove untagged images after 7 days

## Security considerations

None
