### PR TITLE
Update audit scripts to scan latest image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,11 +20,13 @@ jobs:
     params:
       format: oci
     resource: ecr-harden-concourse-task
+  - load_var: latest-tag
+    file: image-source/tag
   - task: audit
     file: scan-source/ci/audit-ecr-container.yml
     vars:
       image: harden-concourse-task
-      tag: ((harden-concourse-task-tag))
+      tag: ((.:latest-tag))
   on_success:
     put: send-an-email
     params:
@@ -44,11 +46,13 @@ jobs:
     params:
       format: oci
     resource: ecr-harden-s3-resource-simple
+  - load_var: latest-tag
+    file: image-source/tag
   - task: audit
     file: scan-source/ci/audit-ecr-container.yml
     vars:
       image: harden-s3-resource-simple
-      tag: ((harden-s3-resource-simple-tag))
+      tag: ((.:latest-tag))
   on_success:
     put: send-an-email
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Changes audit scripts to use latest image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Allows us to audit our latest image
