### PR TITLE
Update pipeline to use grype ignore file in repo instead of s3

### DIFF
--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -20,5 +20,5 @@ printf "${CONFIG}" > ~/.docker/config.json
 TAG=$(cat image-source/tag)
 
 #scan
-grype ${IMAGE}:${TAG} -c ci/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
+grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
 

--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -20,6 +20,5 @@ printf "${CONFIG}" > ~/.docker/config.json
 TAG=$(cat image-source/tag)
 
 #scan
-cp grype-scan-ignore-config/grype.yaml ~/grype.yaml
-grype ${IMAGE}:${TAG} -c grype-scan-ignore-config/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
+grype ${IMAGE}:${TAG} -c ci/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
 

--- a/ci/conmon-scan-ecr-container.yml
+++ b/ci/conmon-scan-ecr-container.yml
@@ -11,7 +11,6 @@ image_resource:
     tag: ((harden-concourse-task-tag))
 
 inputs: 
-- name: grype-scan-ignore-config
 - name: scan-source
 - name: image-source
 

--- a/ci/grype.yaml
+++ b/ci/grype.yaml
@@ -1,0 +1,6 @@
+#Grype ignore configurations.
+
+ignore:
+  - vulnerability: CVE-2007-4642  #false positive, alerting on package of same name
+  - vulnerability: CVE-2007-4644  #false positive, alerting on package of same name
+  - vulnerability: CVE-2018-20225 #disputed as intended functionality

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -72,8 +72,6 @@ jobs:
     params:
       format: oci
     resource: ecr-harden-concourse-task
-  - get: grype-scan-ignore-config
-    trigger: false
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -100,8 +98,6 @@ jobs:
     params:
       format: oci
     resource: ecr-harden-s3-resource-simple
-  - get: grype-scan-ignore-config
-    trigger: false
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -128,8 +124,6 @@ jobs:
     params:
       format: oci
     resource: ecr-sql-clients
-  - get: grype-scan-ignore-config
-    trigger: false
   - task: prep-email
     file: scan-source/ci/conmon-scan-ecr-container.yml
     params:
@@ -155,8 +149,6 @@ jobs:
     - get: weekly
       trigger: true
     - get: scan-source
-      trigger: false
-    - get: grype-scan-ignore-config
       trigger: false
     - get: ecr-harden-concourse-task
       params:
@@ -201,8 +193,6 @@ jobs:
     - get: weekly
       trigger: true
     - get: scan-source
-      trigger: false
-    - get: grype-scan-ignore-config
       trigger: false
     - get: ecr-harden-s3-resource-simple
       params:
@@ -252,8 +242,6 @@ jobs:
       trigger: true
     - get: scan-source
       trigger: false
-    - get: grype-scan-ignore-config
-      trigger: false
   - task: scan
     file: scan-source/ci/scan-container.yml
     params:
@@ -296,8 +284,6 @@ jobs:
         format: oci
       trigger: true
     - get: scan-source
-      trigger: false
-    - get: grype-scan-ignore-config
       trigger: false
   - task: scan
     file: scan-source/ci/scan-container.yml
@@ -446,8 +432,6 @@ jobs:
     - get: scan-source
       trigger: false
       passed: [list-tags-oracle-client]
-    - get: grype-scan-ignore-config
-      trigger: false
     - get: gsa-oracle-client
       params:
         format: oci
@@ -500,8 +484,6 @@ jobs:
     - get: scan-source
       trigger: false
       passed: [list-tags-sql-clients]
-    - get: grype-scan-ignore-config
-      trigger: false
     - get: gsa-sql-clients
       params:
         format: oci
@@ -554,8 +536,6 @@ jobs:
     - get: scan-source
       trigger: false
       passed: [list-tags-harden-concourse-task]
-    - get: grype-scan-ignore-config
-      trigger: false
     - get: gsa-concourse-task
       params:
         format: oci
@@ -608,8 +588,6 @@ jobs:
     - get: scan-source
       trigger: false
       passed: [list-tags-harden-s3-resource-simple]
-    - get: grype-scan-ignore-config
-      trigger: false
     - get: gsa-concourse-task
       params:
         format: oci
@@ -682,7 +660,8 @@ resources:
             "ci/audit-ecr-container.sh",
             "ci/audit-ecr-container.yml",
             "ci/ecr-cve-check.sh",
-            "ci/ecr-cve-check.yml"]
+            "ci/ecr-cve-check.yml",
+            "ci/grype.yml"]
     commit_verification_keys: ((cloud-gov-pgp-keys))      
 
 - name: terraform-config
@@ -804,13 +783,6 @@ resources:
     expression: "0 6 22 * *"
     location: "America/New_York"
     fire_immediately: true
-
-- name: grype-scan-ignore-config
-  type: s3-simple
-  source:
-    bucket: cg-container-scanning
-    region: us-gov-west-1
-    
 
 resource_types:
 - name: slack-notification

--- a/ci/scan-container.sh
+++ b/ci/scan-container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o json --file cves/output.json
-grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o table --file table.txt
+grype ${IMAGE} -c scan-source/ci/grype.yaml -q -o json --file cves/output.json
+grype ${IMAGE} -c scan-source/ci/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 

--- a/ci/scan-container.yml
+++ b/ci/scan-container.yml
@@ -11,7 +11,6 @@ image_resource:
     tag: ((harden-concourse-task-tag))
 
 inputs: 
-- name: grype-scan-ignore-config
 - name: scan-source
 
 outputs:

--- a/ci/scan-ecr-container.sh
+++ b/ci/scan-ecr-container.sh
@@ -18,8 +18,8 @@ mkdir ~/.docker
 printf "${CONFIG}" > ~/.docker/config.json
 
 #scan
-grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o json --file cves/output.json
-grype ${IMAGE} -c grype-scan-ignore-config/grype.yaml -q -o table --file table.txt
+grype ${IMAGE} -c ci/grype.yaml -q -o json --file cves/output.json
+grype ${IMAGE} -c ci/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 

--- a/ci/scan-ecr-container.sh
+++ b/ci/scan-ecr-container.sh
@@ -18,8 +18,8 @@ mkdir ~/.docker
 printf "${CONFIG}" > ~/.docker/config.json
 
 #scan
-grype ${IMAGE} -c ci/grype.yaml -q -o json --file cves/output.json
-grype ${IMAGE} -c ci/grype.yaml -q -o table --file table.txt
+grype ${IMAGE} -c scan-source/ci/grype.yaml -q -o json --file cves/output.json
+grype ${IMAGE} -c scan-source/ci/grype.yaml -q -o table --file table.txt
 
 cat cves/output.json | jq '.matches | .[]? |  .vulnerability.severity' >> severity.txt
 

--- a/ci/scan-ecr-container.yml
+++ b/ci/scan-ecr-container.yml
@@ -11,7 +11,6 @@ image_resource:
     tag: ((harden-concourse-task-tag))
 
 inputs: 
-- name: grype-scan-ignore-config
 - name: scan-source
 
 outputs:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds grype ignore file to repo and updates pipeline to use that file instead of the file in s3

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, any CVEs listed in the ignore file should be ones that are false positives or don't actually affect us
