### PR TITLE
Create staging env

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -169,13 +169,9 @@ jobs:
     put: send-an-email
     params:
       subject_text: "ConMon Results for harden-s3-resource-simple image scans"
+      body_text: "Here is the conmon results for s3-resource-simple"
+      attachment_globs: ["output/s3-resource-simple.xml"]
       REGISTRY: ((aws-ecr-registry))
-  on_success:
-    put: send-an-email
-    params:
-      subject_text: "ConMon Results for harden-concourse-task image scans"
-      body_text: "Here is the conmon results for harden-concourse-task"
-      attachment_globs: ["output/concourse-task.xml"]
   on_failure:
     put: send-an-email
     params:
@@ -197,7 +193,6 @@ jobs:
       FILE: sql-clients
       IMAGE: "((sql-clients-repo))"
       AWS_DEFAULT_REGION: us-gov-west-1
-      REGISTRY: ((aws-ecr-registry))
   on_success:
     put: send-an-email
     params:
@@ -907,8 +902,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: create-staging-env
-      #main
+    branch: main
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -1132,7 +1126,6 @@ groups:
   - audit-harden-concourse-task-staging
   - audit-harden-s3-resource-simple-staging
   - conmon-harden-concourse-task
-  - conmon-harden-concourse-task
   - conmon-harden-s3-resource-simple
   - conmon-18fgsa-sql-clients
   - scan-18fgsa-oracle-client
@@ -1187,3 +1180,4 @@ groups:
 - name: audit
   jobs:
   - audit-harden-concourse-task
+  - audit-harden-s3-resource-simple

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,6 +1,5 @@
 ---
 jobs:
-
 - name: configure-pipeline
   plan:
   - in_parallel:
@@ -9,6 +8,36 @@ jobs:
       params: {depth: 1}
   - set_pipeline: self
     file: pipeline-source/ci/pipeline.yml
+
+- name: audit-harden-concourse-task-staging
+  plan:
+  - in_parallel: &common_resources
+    - get: monthly
+      trigger: true
+    - get: scan-source
+      trigger: false
+  - get: image-source
+    params:
+      format: oci
+    resource: ecr-harden-concourse-task-staging
+  - load_var: latest-tag
+    file: image-source/tag
+  - task: audit
+    file: scan-source/ci/audit-ecr-container.yml
+    vars:
+      image: harden-concourse-task-staging
+      tag: ((.:latest-tag))
+  on_success:
+    put: send-an-email
+    params:
+      subject_text: "Audit Results for harden-concourse-task-staging image"
+      body_text: "Here are the audit results for harden-concourse-task-staging"
+      attachment_globs: ["audit/cis-audit.html"]
+  on_failure:
+    put: send-an-email
+    params:
+      subject_text: "Audit Results for harden-concourse-task-staging image - Failure"
+      body_text: "The pipeline to audit-harden-concourse-task-staging has failed! Please check me out *wink*"
 
 - name: audit-harden-concourse-task
   plan:
@@ -39,6 +68,32 @@ jobs:
     params:
       subject_text: "Audit Results for harden-concourse-task image - Failure"
       body_text: "The pipeline to audit-harden-concourse-task has failed! Please check me out *wink*"
+
+- name: audit-harden-s3-resource-simple-tasking
+  plan:
+  - in_parallel: *common_resources
+  - get: image-source
+    params:
+      format: oci
+    resource: ecr-harden-s3-resource-simple-tasking
+  - load_var: latest-tag
+    file: image-source/tag
+  - task: audit
+    file: scan-source/ci/audit-ecr-container.yml
+    vars:
+      image: harden-s3-resource-simple-tasking
+      tag: ((.:latest-tag))
+  on_success:
+    put: send-an-email
+    params:
+      subject_text: "Audit Results for harden-s3-resource-simple-tasking image"
+      body_text: "Here are the audit results for harden-s3-resource-simple-tasking"
+      attachment_globs: ["audit/cis-audit.html"]
+  on_failure:
+    put: send-an-email
+    params:
+      subject_text: "Audit Results for harden-s3-resource-simple-tasking image - Failure"
+      body_text: "The pipeline to audit-harden-s3-resource-simple-tasking has failed! Please check me out *wink*"
 
 - name: audit-harden-s3-resource-simple
   plan:
@@ -183,6 +238,52 @@ jobs:
       subject_text: "ConMon Results for sql-clients image scans - Failure"
       body_text: "The pipeline to conmon-18fgsa-sql-clients has failed! Please check me out *wink*"
 
+- name: scan-latest-harden-concourse-task-image-staging
+  plan:
+  - in_parallel:
+    - get: weekly
+      trigger: true
+    - get: scan-source
+      trigger: false
+    - get: grype-scan-ignore-config
+      trigger: false
+    - get: ecr-harden-concourse-task-staging
+      params:
+        format: oci
+      trigger: true
+  - load_var: tag
+    file: ecr-harden-concourse-task-staging/tag
+  - task: scan
+    file: scan-source/ci/scan-ecr-container.yml
+    params:
+      IMAGE: "((harden-concourse-task-staging-repo)):((.:tag))"
+      AWS_DEFAULT_REGION: us-gov-west-1
+      REGISTRY: ((aws-ecr-registry))
+  - task: check
+    file: scan-source/ci/ecr-cve-check.yml
+    params:
+      IMAGE: "((harden-concourse-task-staging-repo)):((.:tag))"
+      IMAGENAME: "harden-concourse-task-staging:((.:tag))"
+    on_failure:
+      put: slack
+      params:
+        text:  |
+          :x: FAILED harden-concourse-task-staging CVE check
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: '#cg-platform-news'
+        username: ((username))
+        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+    on_success:
+      put: slack
+      params:
+        text_file: message/alert.txt
+        text: |
+          $TEXT_FILE_CONTENT
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: '#cg-platform-news'
+        username: ((username))
+        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
 - name: scan-latest-harden-concourse-task-image
   plan:
   - in_parallel:
@@ -214,6 +315,52 @@ jobs:
       params:
         text:  |
           :x: FAILED harden-concourse-task CVE check
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: '#cg-platform-news'
+        username: ((username))
+        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+    on_success:
+      put: slack
+      params:
+        text_file: message/alert.txt
+        text: |
+          $TEXT_FILE_CONTENT
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: '#cg-platform-news'
+        username: ((username))
+        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
+- name: scan-latest-harden-s3-resource-simple-image-staging
+  plan:
+  - in_parallel:
+    - get: weekly
+      trigger: true
+    - get: scan-source
+      trigger: false
+    - get: grype-scan-ignore-config
+      trigger: false
+    - get: ecr-harden-s3-resource-simple-staging
+      params:
+        format: oci
+      trigger: true
+  - load_var: tag
+    file: ecr-harden-s3-resource-simple-staging/tag
+  - task: scan
+    file: scan-source/ci/scan-ecr-container.yml
+    params:
+      IMAGE: "((harden-s3-resource-simple-repo)):((.:tag))"
+      AWS_DEFAULT_REGION: us-gov-west-1
+      REGISTRY: ((aws-ecr-registry))
+  - task: check
+    file: scan-source/ci/ecr-cve-check.yml
+    params:
+      IMAGE: "((harden-s3-resource-simple-repo-staging)):((.:tag))"
+      IMAGENAME: "harden-s3-resource-simple-staging:((.:tag))"
+    on_failure:
+      put: slack
+      params:
+        text:  |
+          :x: FAILED harden-s3-resource-simple-staging CVE check
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: '#cg-platform-news'
         username: ((username))
@@ -774,12 +921,21 @@ resources:
     aws_region: us-gov-west-1
     semver_constraint: ">= 1.0.0"
 
-- name: ecr-harden-concourse-task
+- name: ecr-harden-concourse-task-staging
   type: registry-image
   source:
     aws_access_key_id: ((aws-key))
     aws_secret_access_key: ((aws-secret))
-    repository: harden-concourse-task
+    repository: harden-concourse-task-staging
+    aws_region: us-gov-west-1
+    semver_constraint: ">= 1.0.0"
+
+- name: ecr-harden-concourse-task-staging
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: harden-concourse-task-staging
     aws_region: us-gov-west-1
     semver_constraint: ">= 1.0.0"
 
@@ -846,6 +1002,9 @@ groups:
   - configure-pipeline
   - audit-harden-concourse-task
   - audit-harden-s3-resource-simple
+  - audit-harden-concourse-task-staging
+  - audit-harden-s3-resource-simple-staging
+  - conmon-harden-concourse-task
   - conmon-harden-concourse-task
   - conmon-harden-s3-resource-simple
   - conmon-18fgsa-sql-clients
@@ -859,6 +1018,10 @@ groups:
   - list-tags-harden-s3-resource-simple
   - scan-ecr-oracle-client
   - scan-ecr-sql-clients
+  - scan-ecr-harden-concourse-task-staging
+  - scan-ecr-harden-s3-resource-simple-staging
+  - scan-latest-harden-concourse-task-image-staging
+  - scan-latest-harden-s3-resource-simple-image-staging
   - scan-ecr-harden-concourse-task
   - scan-ecr-harden-s3-resource-simple
   - scan-latest-harden-concourse-task-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -916,8 +916,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: create-staging-env
-      #main
+    branch: main
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -942,8 +941,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: create-staging-env
-      #main
+    branch: main
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -182,34 +182,6 @@ jobs:
       subject_text: "ConMon Results for harden-concourse-task image scans - Failure"
       body_text: "The pipeline to conmon-harden-concourse-task has failed! Please check me out *wink*"
 
-- name: conmon-harden-s3-resource-simple
-  plan:
-  - in_parallel: *common_resources
-  - get: image-source
-    params:
-      format: oci
-    resource: ecr-harden-s3-resource-simple
-  - get: grype-scan-ignore-config
-    trigger: false
-  - task: prep-email
-    file: scan-source/ci/conmon-scan-ecr-container.yml
-    params:
-      FILE: s3-resource-simple
-      IMAGE: "((harden-s3-resource-simple-repo))"
-      AWS_DEFAULT_REGION: us-gov-west-1
-      REGISTRY: ((aws-ecr-registry))
-  on_success:
-    put: send-an-email
-    params:
-      subject_text: "ConMon Results for harden-s3-resource-simple image scans"
-      body_text: "Here is the conmon results for s3-resource-simple"
-      attachment_globs: ["output/s3-resource-simple.xml"]
-  on_failure:
-    put: send-an-email
-    params:
-      subject_text: "ConMon Results for harden-s3-resource-simple image scans - Failure"
-      body_text: "The pipeline to conmon-harden-s3-resource-simple has failed! Please check me out *wink*"
-
 - name: conmon-18fgsa-sql-clients
   plan:
   - in_parallel: *common_resources
@@ -1037,6 +1009,15 @@ resources:
     aws_region: us-gov-west-1
     semver_constraint: ">= 1.0.0"
 
+- name: ecr-harden-s3-resource-simple-staging
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: harden-s3-resource-simple-staging
+    aws_region: us-gov-west-1
+    semver_constraint: ">= 1.0.0"
+
 - name: ecr-harden-s3-resource-simple
   type: registry-image
   source:
@@ -1060,11 +1041,25 @@ resources:
     versioned_file: ecr/tags-sql-clients.json
     region_name: us-gov-west-1
 
+- name: image-tags-harden-concourse-task-staging
+  type: s3-iam
+  source:
+    bucket: ((tf-state-bucket))
+    versioned_file: ecr/tags-harden-concourse-task.json
+    region_name: us-gov-west-1
+
 - name: image-tags-harden-concourse-task
   type: s3-iam
   source:
     bucket: ((tf-state-bucket))
     versioned_file: ecr/tags-harden-concourse-task.json
+    region_name: us-gov-west-1
+
+- name: image-tags-harden-s3-resource-simple-staging
+  type: s3-iam
+  source:
+    bucket: ((tf-state-bucket))
+    versioned_file: ecr/tags-harden-s3-resource-simple.json
     region_name: us-gov-west-1
 
 - name: image-tags-harden-s3-resource-simple

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -171,7 +171,6 @@ jobs:
       subject_text: "ConMon Results for harden-s3-resource-simple image scans"
       body_text: "Here is the conmon results for s3-resource-simple"
       attachment_globs: ["output/s3-resource-simple.xml"]
-      REGISTRY: ((aws-ecr-registry))
   on_failure:
     put: send-an-email
     params:
@@ -193,6 +192,7 @@ jobs:
       FILE: sql-clients
       IMAGE: "((sql-clients-repo))"
       AWS_DEFAULT_REGION: us-gov-west-1
+      REGISTRY: ((aws-ecr-registry))
   on_success:
     put: send-an-email
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -174,8 +174,8 @@ jobs:
   on_failure:
     put: send-an-email
     params:
-      subject_text: "ConMon Results for harden-concourse-task image scans - Failure"
-      body_text: "The pipeline to conmon-harden-concourse-task has failed! Please check me out *wink*"
+      subject_text: "ConMon Results for harden-s3-resource-simple image scans - Failure"
+      body_text: "The pipeline to conmon-harden-s3-resource-simple has failed! Please check me out *wink*"
 
 - name: conmon-18fgsa-sql-clients
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -915,7 +915,8 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: create-staging-env
+      #main
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -940,7 +941,8 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: create-staging-env
+      #main
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -948,7 +950,8 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-pipeline-tasks.git
-    branch: main
+    branch: create-staging-env
+      #main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: gsa-oracle-client

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -69,31 +69,31 @@ jobs:
       subject_text: "Audit Results for harden-concourse-task image - Failure"
       body_text: "The pipeline to audit-harden-concourse-task has failed! Please check me out *wink*"
 
-- name: audit-harden-s3-resource-simple-tasking
+- name: audit-harden-s3-resource-simple-staging
   plan:
   - in_parallel: *common_resources
   - get: image-source
     params:
       format: oci
-    resource: ecr-harden-s3-resource-simple-tasking
+    resource: ecr-harden-s3-resource-simple-staging
   - load_var: latest-tag
     file: image-source/tag
   - task: audit
     file: scan-source/ci/audit-ecr-container.yml
     vars:
-      image: harden-s3-resource-simple-tasking
+      image: harden-s3-resource-simple-staging
       tag: ((.:latest-tag))
   on_success:
     put: send-an-email
     params:
-      subject_text: "Audit Results for harden-s3-resource-simple-tasking image"
-      body_text: "Here are the audit results for harden-s3-resource-simple-tasking"
+      subject_text: "Audit Results for harden-s3-resource-simple-staging image"
+      body_text: "Here are the audit results for harden-s3-resource-simple-staging"
       attachment_globs: ["audit/cis-audit.html"]
   on_failure:
     put: send-an-email
     params:
-      subject_text: "Audit Results for harden-s3-resource-simple-tasking image - Failure"
-      body_text: "The pipeline to audit-harden-s3-resource-simple-tasking has failed! Please check me out *wink*"
+      subject_text: "Audit Results for harden-s3-resource-simple-staging image - Failure"
+      body_text: "The pipeline to audit-harden-s3-resource-simple-staging has failed! Please check me out *wink*"
 
 - name: audit-harden-s3-resource-simple
   plan:
@@ -348,13 +348,13 @@ jobs:
   - task: scan
     file: scan-source/ci/scan-ecr-container.yml
     params:
-      IMAGE: "((harden-s3-resource-simple-repo)):((.:tag))"
+      IMAGE: "((harden-s3-resource-simple-staging-repo)):((.:tag))"
       AWS_DEFAULT_REGION: us-gov-west-1
       REGISTRY: ((aws-ecr-registry))
   - task: check
     file: scan-source/ci/ecr-cve-check.yml
     params:
-      IMAGE: "((harden-s3-resource-simple-repo-staging)):((.:tag))"
+      IMAGE: "((harden-s3-resource-simple-staging-repo)):((.:tag))"
       IMAGENAME: "harden-s3-resource-simple-staging:((.:tag))"
     on_failure:
       put: slack
@@ -724,6 +724,60 @@ jobs:
           username: ((username))
           icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
+- name: scan-ecr-harden-concourse-task-staging
+  plan:
+  - in_parallel:
+    - get: image-tags-harden-concourse-task-staging
+      trigger: true
+    - get: weekly
+      trigger: true
+      passed: [scan-ecr-harden-concourse-task]
+    - get: scan-source
+      trigger: false
+      passed: [scan-ecr-harden-concourse-task]
+    - get: grype-scan-ignore-config
+      trigger: false
+    - get: gsa-concourse-task
+      params:
+        format: oci
+      resource: ecr-harden-concourse-task-staging
+  - load_var: tags
+    file: image-tags-harden-concourse-task-staging/tags-harden-concourse-task.json
+  - across:
+    - var: tag
+      values: ((.:tags))
+    do:
+    - task: scan
+      file: scan-source/ci/scan-ecr-container.yml
+      params:
+        IMAGE: "((harden-concourse-task-staging-repo)):((.:tag))"
+        AWS_DEFAULT_REGION: us-gov-west-1
+        REGISTRY: ((aws-ecr-registry))
+    - task: check
+      file: scan-source/ci/ecr-cve-check.yml
+      params:
+        IMAGE: "((harden-concourse-task-staging-repo)):((.:tag))"
+        IMAGENAME: "harden-concourse-task-staging:((.:tag))"
+      on_failure:
+        put: slack
+        params:
+          text:  |
+            :x: FAILED harden-concourse-task CVE check
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          channel: '#cg-platform-news'
+          username: ((username))
+          icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+      on_success:
+        put: slack
+        params:
+          text_file: message/alert.txt
+          text: |
+            $TEXT_FILE_CONTENT
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          channel: '#cg-platform-news'
+          username: ((username))
+          icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
 - name: scan-ecr-harden-concourse-task
   plan:
   - in_parallel:
@@ -773,6 +827,50 @@ jobs:
           text_file: message/alert.txt
           text: |
             $TEXT_FILE_CONTENT
+            <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          channel: '#cg-platform-news'
+          username: ((username))
+          icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+
+- name: scan-ecr-harden-s3-resource-simple-staging
+  plan:
+  - in_parallel:
+    - get: image-tags-harden-s3-resource-simple-staging
+      trigger: true
+    - get: weekly
+      trigger: true
+      passed: [scan-ecr-harden-s3-resource-simple]
+    - get: scan-source
+      trigger: false
+      passed: [scan-ecr-harden-s3-resource-simple]
+    - get: grype-scan-ignore-config
+      trigger: false
+    - get: gsa-concourse-task
+      params:
+        format: oci
+      resource: ecr-harden-s3-resource-simple-staging
+  - load_var: tags
+    file: image-tags-harden-s3-resource-simple-staging/tags-harden-s3-resource-simple-staging.json
+  - across:
+    - var: tag
+      values: ((.:tags))
+    do:
+    - task: scan
+      file: scan-source/ci/scan-ecr-container.yml
+      params:
+        IMAGE: "((harden-s3-resource-simple-staging-repo)):((.:tag))"
+        AWS_DEFAULT_REGION: us-gov-west-1
+        REGISTRY: ((aws-ecr-registry))
+    - task: check
+      file: scan-source/ci/ecr-cve-check.yml
+      params:
+        IMAGE: "((harden-s3-resource-simple-staging-repo)):((.:tag))"
+        IMAGENAME: "harden-s3-resource-simple-staging:((.:tag))"
+      on_failure:
+        put: slack
+        params:
+          text:  |
+            :x: FAILED harden-s3-resource-simple CVE check
             <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
           channel: '#cg-platform-news'
           username: ((username))
@@ -921,12 +1019,12 @@ resources:
     aws_region: us-gov-west-1
     semver_constraint: ">= 1.0.0"
 
-- name: ecr-harden-concourse-task-staging
+- name: ecr-harden-concourse-task
   type: registry-image
   source:
     aws_access_key_id: ((aws-key))
     aws_secret_access_key: ((aws-secret))
-    repository: harden-concourse-task-staging
+    repository: harden-concourse-task
     aws_region: us-gov-west-1
     semver_constraint: ">= 1.0.0"
 
@@ -959,7 +1057,6 @@ resources:
   type: s3-iam
   source:
     bucket: ((tf-state-bucket))
-???
     fire_immediately: true
 
 - name: grype-scan-ignore-config

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,5 +1,6 @@
 ---
 jobs:
+
 - name: configure-pipeline
   plan:
   - in_parallel:
@@ -80,6 +81,39 @@ jobs:
       FILE: concourse-task
       IMAGE: "((harden-concourse-task-repo))"
       AWS_DEFAULT_REGION: us-gov-west-1
+      REGISTRY: ((aws-ecr-registry))
+  on_success:
+    put: send-an-email
+    params:
+      subject_text: "ConMon Results for harden-concourse-task image scans"
+      body_text: "Here is the conmon results for harden-concourse-task"
+      attachment_globs: ["output/concourse-task.xml"]
+  on_failure:
+    put: send-an-email
+    params:
+      subject_text: "ConMon Results for harden-concourse-task image scans - Failure"
+      body_text: "The pipeline to conmon-harden-concourse-task has failed! Please check me out *wink*"
+
+- name: conmon-harden-s3-resource-simple
+  plan:
+  - in_parallel: *common_resources
+  - get: image-source
+    params:
+      format: oci
+    resource: ecr-harden-s3-resource-simple
+  - get: grype-scan-ignore-config
+    trigger: false
+  - task: prep-email
+    file: scan-source/ci/conmon-scan-ecr-container.yml
+    params:
+      FILE: s3-resource-simple
+      IMAGE: "((harden-s3-resource-simple-repo))"
+      AWS_DEFAULT_REGION: us-gov-west-1
+      REGISTRY: ((aws-ecr-registry))
+  on_success:
+    put: send-an-email
+    params:
+      subject_text: "ConMon Results for harden-s3-resource-simple image scans"
       REGISTRY: ((aws-ecr-registry))
   on_success:
     put: send-an-email
@@ -769,40 +803,7 @@ resources:
   type: s3-iam
   source:
     bucket: ((tf-state-bucket))
-    versioned_file: ecr/tags-sql-clients.json
-    region_name: us-gov-west-1
-
-- name: image-tags-harden-concourse-task
-  type: s3-iam
-  source:
-    bucket: ((tf-state-bucket))
-    versioned_file: ecr/tags-harden-concourse-task.json
-    region_name: us-gov-west-1
-
-- name: image-tags-harden-s3-resource-simple
-  type: s3-iam
-  source:
-    bucket: ((tf-state-bucket))
-    versioned_file: ecr/tags-harden-s3-resource-simple.json
-    region_name: us-gov-west-1
-
-- name: send-an-email
-  type: email-resource
-  source:
-    smtp:
-      host: ((smtp-host))
-      port: ((smtp-port))
-      username: ((smtp-cloudgovbilling.username))
-      password: ((smtp-cloudgovbilling.password))
-      ca_cert: ((smtp-cert.certificate))
-    from: ((smtp-email-from))
-    to: [((smtp-email-to))]
-
-- name: monthly
-  type: cron-resource
-  source:
-    expression: "0 6 22 * *"
-    location: "America/New_York"
+???
     fire_immediately: true
 
 - name: grype-scan-ignore-config
@@ -896,4 +897,3 @@ groups:
 - name: audit
   jobs:
   - audit-harden-concourse-task
-  - audit-harden-s3-resource-simple

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -907,7 +907,8 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: create-staging-env
+      #main
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -950,8 +951,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-pipeline-tasks.git
-    branch: create-staging-env
-      #main
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: gsa-oracle-client

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -910,7 +910,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: create-staging-env #main
+    branch: main
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -935,7 +935,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: create-staging-env #main
+    branch: main
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -910,7 +910,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: create-staging-env #main
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -935,7 +935,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: create-staging-env #main
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1057,6 +1057,40 @@ resources:
   type: s3-iam
   source:
     bucket: ((tf-state-bucket))
+    versioned_file: ecr/tags-sql-clients.json
+    region_name: us-gov-west-1
+
+- name: image-tags-harden-concourse-task
+  type: s3-iam
+  source:
+    bucket: ((tf-state-bucket))
+    versioned_file: ecr/tags-harden-concourse-task.json
+    region_name: us-gov-west-1
+
+- name: image-tags-harden-s3-resource-simple
+  type: s3-iam
+  source:
+    bucket: ((tf-state-bucket))
+    versioned_file: ecr/tags-harden-s3-resource-simple.json
+    region_name: us-gov-west-1
+
+- name: send-an-email
+  type: email-resource
+  source:
+    smtp:
+      host: ((smtp-host))
+      port: ((smtp-port))
+      username: ((smtp-cloudgovbilling.username))
+      password: ((smtp-cloudgovbilling.password))
+      ca_cert: ((smtp-cert.certificate))
+    from: ((smtp-email-from))
+    to: [((smtp-email-to))]
+
+- name: monthly
+  type: cron-resource
+  source:
+    expression: "0 6 22 * *"
+    location: "America/New_York"
     fire_immediately: true
 
 - name: grype-scan-ignore-config

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -6,7 +6,7 @@ variable "tooling_stack_name" {
 
 variable "repositories" {
   type = list(string)
-  default = ["concourse-task","s3-resource-simple","oracle-client","sql-clients","harden-concourse-task","harden-s3-resource-simple", "harden-concourse-task-staging", "harden-s3-resource-simple-staging"]
+  default = ["concourse-task","s3-resource-simple","oracle-client","sql-clients","harden-concourse-task","harden-s3-resource-simple","harden-concourse-task-staging","harden-s3-resource-simple-staging"]
 }
 
 terraform {

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -6,7 +6,7 @@ variable "tooling_stack_name" {
 
 variable "repositories" {
   type = list(string)
-  default = ["concourse-task","s3-resource-simple","oracle-client","sql-clients","harden-concourse-task","harden-s3-resource-simple"]
+  default = ["concourse-task","s3-resource-simple","oracle-client","sql-clients","harden-concourse-task","harden-s3-resource-simple", "harden-concourse-task-staging", "harden-s3-resource-simple-staging"]
 }
 
 terraform {

--- a/terraform/terraform-apply.yml
+++ b/terraform/terraform-apply.yml
@@ -7,7 +7,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs:
 - name: terraform-templates


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added audit and scan tasks for staging versions of both the concourse and s3 images

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- There is no logging or actual code changes, this is strictly adding images for staging to prep for gating into the prod environment

## Security considerations

This increases security as we are adding checks for images before they are deployed to production