### PR TITLE
CVE gating

### DIFF
--- a/ci/delete-image.sh
+++ b/ci/delete-image.sh
@@ -3,5 +3,6 @@
 set -e -x
 
 aws ecr batch-delete-image \
-     --repository-name $IMAGE_REPOSITORY \
-     --image-ids imageTag=1.0.2
+     --repository-name ${IMAGE_REPOSITORY} \
+     --image-ids imageTag=${IMAGE_TAG} \
+     --region ${AWS_DEFAULT_REGION}

--- a/ci/ecr-cve-check.sh
+++ b/ci/ecr-cve-check.sh
@@ -83,6 +83,10 @@ for failed_issue in ${failed_cves[@]}; do
     echo "      $failed_issue"
 done
 
+if [ ${#past_due_critical_cves[@]} -ge 1 ] || [ ${#past_due_high_cves[@]} -ge 1 ]
+then exit 1
+fi
+
 if [ ${#current_critical_cves[@]} -ge 1 ] || [ ${#current_high_cves[@]} -ge 1 ]
 then echo ":warning: CVEs need to be reviewed for image ${IMAGENAME}." > message/alert.txt
 else echo ":white_check_mark: ${IMAGENAME} passed CVE check" > message/alert.txt

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -296,51 +296,6 @@ jobs:
         username: ((username))
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
-- name: scan-latest-hardened-s3-resource-simple-image
-  old_name: scan-latest-harden-s3-resource-simple-image
-  plan:
-  - in_parallel:
-    - get: weekly
-      trigger: true
-    - get: scan-source
-      trigger: false
-    - get: ecr-harden-s3-resource-simple-repo
-      params:
-        format: oci
-      trigger: true
-  - load_var: tag
-    file: ecr-harden-s3-resource-simple-repo/tag
-  - task: scan
-    file: scan-source/ci/scan-ecr-container.yml
-    params:
-      IMAGE: "((harden-s3-resource-simple-repo)):((.:tag))"
-      AWS_DEFAULT_REGION: us-gov-west-1
-      REGISTRY: ((aws-ecr-registry))
-  - task: check
-    file: scan-source/ci/ecr-cve-check.yml
-    params:
-      IMAGE: "((harden-s3-resource-simple-repo)):((.:tag))"
-      IMAGENAME: "harden-s3-resource-simple:((.:tag))"
-    on_failure:
-      put: slack
-      params:
-        text:  |
-          :x: FAILED harden-s3-resource-simple CVE check
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: '#cg-platform-news'
-        username: ((username))
-        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
-    on_success:
-      put: slack
-      params:
-        text_file: message/alert.txt
-        text: |
-          $TEXT_FILE_CONTENT
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: '#cg-platform-news'
-        username: ((username))
-        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
-
 - name: scan-oracle-client-docker-image
   old_name: scan-18fgsa-oracle-client
   plan:
@@ -539,7 +494,7 @@ jobs:
   plan:
   - in_parallel:
     - get: scan-source
-      passed: [scan-latest-hardened-s3-resource-simple-image]
+      passed: [upload-hardened-s3-resource-simple-prod-image]
     - get: weekly
       trigger: true
     - get: ecr-harden-s3-resource-simple-repo
@@ -857,15 +812,31 @@ jobs:
     params:
       format: oci
     resource: ecr-hardened-concourse-task-staging-repo
-  - get: hardened-concourse-image-prod-version
+  - get: hardened-concourse-task-image-prod-version
     params: {bump: patch}
   - put: ecr-harden-concourse-task-repo
     params:
       image: image-source/image.tar
-      additional_tags: hardened-concourse-image-prod-version/version
-  - put: hardened-concourse-image-prod-version
-    params: {file: hardened-concourse-image-prod-version/version}
+      additional_tags: hardened-concourse-task-image-prod-version/version
+  - put: hardened-concourse-task-image-prod-version
+    params: {file: hardened-concourse-task-image-prod-version/version}
 
+- name: upload-hardened-s3-resource-simple-prod-image
+  plan:
+  - get: scan-source
+    passed: [scan-latest-hardened-s3-resource-simple-staging-image]
+  - get: image-source
+    params:
+      format: oci
+    resource: ecr-hardened-s3-resource-simple-staging-repo
+  - get: hardened-s3-resource-simple-image-prod-version
+    params: {bump: patch}
+  - put: ecr-harden-s3-resource-simple-repo
+    params:
+      image: image-source/image.tar
+      additional_tags: hardened-s3-resource-simple-image-prod-version/version
+  - put: hardened-s3-resource-simple-image-prod-version
+    params: {file: hardened-s3-resource-simple-image-prod-version/version}
 
 resources:
 - name: pipeline-source
@@ -1054,12 +1025,23 @@ resources:
     location: "America/New_York"
     fire_immediately: true
 
-- name: hardened-concourse-image-prod-version
+- name: hardened-concourse-task-image-prod-version
   type: semver
   source:
     driver: s3
     bucket: ((semver-bucket))
     key: harden-concourse-docker-image-version
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
+    initial_version: 1.0.0
+
+- name: hardened-s3-resource-simple-image-prod-version
+  type: semver
+  source:
+    driver: s3
+    bucket: ((semver-bucket))
+    key: harden-s3-resource-simple-image-version
     access_key_id: ((aws-access-key-id))
     secret_access_key: ((aws-secret-access-key))
     region_name: ((aws-region))
@@ -1121,8 +1103,8 @@ groups:
   - scan-latest-hardened-s3-resource-simple-staging-image
   - scan-hardened-concourse-task-image
   - scan-hardened-s3-resource-simple-image
-  - scan-latest-hardened-s3-resource-simple-image
   - upload-hardened-concourse-task-prod-image
+  - upload-hardened-s3-resource-simple-prod-image
 - name: docker-scan
   jobs:
   - scan-oracle-client-docker-image
@@ -1147,7 +1129,7 @@ groups:
 - name: hardened-scan
   jobs:
   - scan-latest-hardened-concourse-task-staging-image
-  - scan-latest-hardened-s3-resource-simple-image
+  - scan-latest-hardened-s3-resource-simple-staging-image
   - list-tags-hardened-concourse-task
   - list-tags-hardened-s3-resource-simple
   - list-tags-hardened-concourse-task-staging

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -899,14 +899,14 @@ jobs:
   - in_parallel:
     - get: scan-source
       passed: [scan-latest-hardened-concourse-task-staging-image]
-    - get: ecr-hardened-s3-resource-simple-staging-repo
+    - get: ecr-hardened-concourse-task-staging-repo
       params:
         format: oci
     - get: hardened-concourse-image-prod-version
       params: {bump: patch}
   - put: ecr-harden-concourse-task-prod-repo
     params:
-      image: ecr-hardened-s3-resource-simple-staging-repo/image.tar
+      image: ecr-hardened-concourse-task-staging-repo/image.tar
       additional_tags: hardened-concourse-image-prod-version/version
   - put: hardened-concourse-image-prod-version
     params: {file: hardened-concourse-image-prod-version/version}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1122,7 +1122,7 @@ groups:
   - scan-hardened-concourse-task-image
   - scan-hardened-s3-resource-simple-image
   - scan-latest-hardened-s3-resource-simple-image
-  - upload-hardened-concourse-prod-image
+  - upload-hardened-concourse-task-prod-image
 - name: docker-scan
   jobs:
   - scan-oracle-client-docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -774,7 +774,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: cve-gating
+    branch: main
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -782,7 +782,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: cve-gating
+    branch: main
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -808,7 +808,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: cve-gating
+    branch: main
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -806,14 +806,16 @@ jobs:
 
 - name: upload-hardened-concourse-task-prod-image
   plan:
-  - get: scan-source
-    passed: [scan-latest-hardened-concourse-task-staging-image]
-  - get: image-source
-    params:
-      format: oci
-    resource: ecr-hardened-concourse-task-staging-repo
-  - get: hardened-concourse-task-image-prod-version
-    params: {bump: patch}
+  - in_parallel:
+    - get: scan-source
+    - get: image-source
+      params:
+        format: oci
+      resource: ecr-hardened-concourse-task-staging-repo
+      passed: [scan-latest-hardened-concourse-task-staging-image]
+      trigger: true
+    - get: hardened-concourse-task-image-prod-version
+      params: {bump: patch}
   - put: ecr-harden-concourse-task-repo
     params:
       image: image-source/image.tar
@@ -823,14 +825,16 @@ jobs:
 
 - name: upload-hardened-s3-resource-simple-prod-image
   plan:
-  - get: scan-source
-    passed: [scan-latest-hardened-s3-resource-simple-staging-image]
-  - get: image-source
-    params:
-      format: oci
-    resource: ecr-hardened-s3-resource-simple-staging-repo
-  - get: hardened-s3-resource-simple-image-prod-version
-    params: {bump: patch}
+  - in_parallel:
+    - get: scan-source
+    - get: image-source
+      params:
+        format: oci
+      resource: ecr-hardened-s3-resource-simple-staging-repo
+      passed: [scan-latest-hardened-s3-resource-simple-staging-image]
+      trigger: true
+    - get: hardened-s3-resource-simple-image-prod-version
+      params: {bump: patch}
   - put: ecr-harden-s3-resource-simple-repo
     params:
       image: image-source/image.tar

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -915,12 +915,6 @@ jobs:
       - name: ecr-hardened-s3-resource-simple-staging-repo
       outputs:
       - name: image
-#  - put: ecr-harden-concourse-task-prod-repo
-#    params:
-#      image: image/image.tar
-#      additional_tags: hardened-concourse-image-prod-version/version
-#  - put: hardened-concourse-image-prod-version
-#    params: {file: hardened-concourse-image-prod-version/version}
 
 resources:
 - name: pipeline-source

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -894,6 +894,34 @@ jobs:
           username: ((username))
           icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
+- name: upload-hardened-concourse-prod-image
+  plan:
+  - in_parallel:
+    - get: scan_source
+      passed: [scan-latest-hardened-concourse-task-staging-image]
+    - get: ecr-hardened-s3-resource-simple-staging-repo
+      passed: [scan-latest-hardened-concourse-task-staging-image]
+      params:
+        format: oci
+  - task: build-staging
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: concourse/oci-build-task
+      inputs:
+      - name: ecr-hardened-s3-resource-simple-staging-repo
+      outputs:
+      - name: image
+#  - put: ecr-harden-concourse-task-prod-repo
+#    params:
+#      image: image/image.tar
+#      additional_tags: hardened-concourse-image-prod-version/version
+#  - put: hardened-concourse-image-prod-version
+#    params: {file: hardened-concourse-image-prod-version/version}
+
 resources:
 - name: pipeline-source
   type: git
@@ -1108,6 +1136,26 @@ resource_types:
   source:
     repository: 18fgsa/s3-resource-simple
 
+- name: ecr-harden-concourse-task-prod-repo
+  type: registry-image
+  source:
+    aws_access_key_id: ((aws-key))
+    aws_secret_access_key: ((aws-secret))
+    repository: harden-concourse-task
+    aws_region: us-gov-west-1
+    semver_constraint: ">= 1.0.0"
+
+- name: hardened-concourse-image-prod-version
+  type: semver
+  source:
+    driver: s3
+    bucket: {{semver-bucket}}
+    key: harden-concourse-docker-image-version
+    access_key_id: {{aws-access-key-id}}
+    secret_access_key: {{aws-secret-access-key}}
+    region_name: {{aws-region}}
+    initial_version: 1.0.0
+
 groups:
 - name: all
   jobs:
@@ -1139,6 +1187,7 @@ groups:
   - scan-hardened-s3-resource-simple-image
   - scan-latest-hardened-concourse-task-image
   - scan-latest-hardened-s3-resource-simple-image
+  - upload-hardened-concourse-prod-image
 - name: docker-scan
   jobs:
   - scan-oracle-client-docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -897,7 +897,7 @@ jobs:
 - name: upload-hardened-concourse-prod-image
   plan:
   - in_parallel:
-    - get: scan_source
+    - get: scan-source
       passed: [scan-latest-hardened-concourse-task-staging-image]
     - get: ecr-hardened-s3-resource-simple-staging-repo
       passed: [scan-latest-hardened-concourse-task-staging-image]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -927,7 +927,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: cve-gating
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -935,7 +935,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: cve-gating
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -961,7 +961,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: cve-gating
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -900,7 +900,6 @@ jobs:
     - get: scan-source
       passed: [scan-latest-hardened-concourse-task-staging-image]
     - get: ecr-hardened-s3-resource-simple-staging-repo
-      passed: [scan-latest-hardened-concourse-task-staging-image]
       params:
         format: oci
   - task: build-staging

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -896,17 +896,17 @@ jobs:
 
 - name: upload-hardened-concourse-prod-image
   plan:
-  - in_parallel:
-    - get: scan-source
-      passed: [scan-latest-hardened-concourse-task-staging-image]
-    - get: ecr-hardened-concourse-task-staging-repo
-      params:
-        format: oci
-    - get: hardened-concourse-image-prod-version
-      params: {bump: patch}
-  - put: ecr-harden-concourse-task-prod-repo
+  - get: scan-source
+    passed: [scan-latest-hardened-concourse-task-staging-image]
+  - get: image-source
     params:
-      image: ecr-hardened-concourse-task-staging-repo/image.tar
+      format: oci
+    resource: ecr-hardened-concourse-task-staging-repo
+  - get: hardened-concourse-image-prod-version
+    params: {bump: patch}
+  - put: ecr-harden-concourse-task-repo
+    params:
+      image: image-source/image.tar
       additional_tags: hardened-concourse-image-prod-version/version
   - put: hardened-concourse-image-prod-version
     params: {file: hardened-concourse-image-prod-version/version}
@@ -1099,6 +1099,17 @@ resources:
     location: "America/New_York"
     fire_immediately: true
 
+- name: hardened-concourse-image-prod-version
+  type: semver
+  source:
+    driver: s3
+    bucket: ((semver-bucket))
+    key: harden-concourse-docker-image-version
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
+    initial_version: 1.0.0
+
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -1125,26 +1136,6 @@ resource_types:
   type: docker-image
   source:
     repository: 18fgsa/s3-resource-simple
-
-- name: ecr-harden-concourse-task-prod-repo
-  type: registry-image
-  source:
-    aws_access_key_id: ((aws-key))
-    aws_secret_access_key: ((aws-secret))
-    repository: harden-concourse-task
-    aws_region: us-gov-west-1
-    semver_constraint: ">= 1.0.0"
-
-- name: hardened-concourse-image-prod-version
-  type: semver
-  source:
-    driver: s3
-    bucket: ((semver-bucket))
-    key: harden-concourse-docker-image-version
-    access_key_id: ((aws-access-key-id))
-    secret_access_key: ((aws-secret-access-key))
-    region_name: ((aws-region))
-    initial_version: 1.0.0
 
 groups:
 - name: all

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -915,6 +915,8 @@ jobs:
       - name: ecr-hardened-s3-resource-simple-staging-repo
       outputs:
       - name: image
+      run:
+        path: build
 
 resources:
 - name: pipeline-source

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -10,7 +10,6 @@ jobs:
     file: pipeline-source/ci/pipeline.yml
 
 - name: audit-hardened-concourse-task-staging-image
-  old_name: audit-harden-concourse-task-staging
   plan:
   - in_parallel: &common_resources
     - get: monthly
@@ -41,7 +40,6 @@ jobs:
       body_text: "The pipeline to audit the latest harden-concourse-task-staging image has failed! Please check me out *wink*"
 
 - name: audit-hardened-s3-resource-simple-staging-image
-  old_name: audit-harden-s3-resource-simple-staging
   plan:
   - in_parallel: *common_resources
   - get: image-source
@@ -68,7 +66,6 @@ jobs:
       body_text: "The pipeline to audit the latest harden-s3-resource-simple-staging image has failed! Please check me out *wink*"
 
 - name: conmon-hardened-concourse-task-image
-  old_name: conmon-harden-concourse-task
   plan:
   - in_parallel: *common_resources
   - get: image-source
@@ -95,7 +92,6 @@ jobs:
       body_text: "The pipeline for conmon-hardened-concourse-task-image has failed! Please check me out *wink*"
 
 - name: conmon-hardened-s3-resource-simple-image
-  old_name: conmon-harden-s3-resource-simple
   plan:
   - in_parallel: *common_resources
   - get: image-source
@@ -122,7 +118,6 @@ jobs:
       body_text: "The pipeline for conmon-hardened-s3-resource-simple-image has failed! Please check me out *wink*"
 
 - name: conmon-18fgsa-sql-clients-image
-  old_name: conmon-18fgsa-sql-clients
   plan:
   - in_parallel: *common_resources
   - get: image-source
@@ -149,7 +144,6 @@ jobs:
       body_text: "The pipeline for conmon-18fgsa-sql-clients-image has failed! Please check me out *wink*"
 
 - name: scan-latest-hardened-concourse-task-staging-image
-  old_name: scan-latest-harden-concourse-task-image-staging
   plan:
   - in_parallel:
     - get: weekly
@@ -194,7 +188,6 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: scan-latest-hardened-s3-resource-simple-staging-image
-  old_name: scan-latest-harden-s3-resource-simple-image-staging
   plan:
   - in_parallel:
     - get: weekly
@@ -239,7 +232,6 @@ jobs:
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: scan-oracle-client-docker-image
-  old_name: scan-18fgsa-oracle-client
   plan:
   - in_parallel:
     - get: weekly
@@ -283,7 +275,6 @@ jobs:
       icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: scan-sql-clients-docker-image
-  old_name: scan-18fgsa-sql-clients
   plan:
   - in_parallel:
     - get: weekly
@@ -399,7 +390,6 @@ jobs:
       STACK_NAME: ecr
 
 - name: list-tags-hardened-concourse-task
-  old_name: list-tags-harden-concourse-task
   plan:
   - in_parallel:
     - get: scan-source
@@ -432,7 +422,6 @@ jobs:
       STACK_NAME: ecr
 
 - name: list-tags-hardened-s3-resource-simple
-  old_name: list-tags-harden-s3-resource-simple
   plan:
   - in_parallel:
     - get: scan-source
@@ -561,7 +550,6 @@ jobs:
           icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: scan-hardened-concourse-task-staging-image
-  old_name: scan-ecr-harden-concourse-task-staging
   plan:
   - in_parallel:
     - get: image-tags-harden-concourse-task-staging
@@ -610,7 +598,6 @@ jobs:
           icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: scan-hardened-concourse-task-image
-  old_name: scan-ecr-harden-concourse-task
   plan:
   - in_parallel:
     - get: image-tags-harden-concourse-task
@@ -659,7 +646,6 @@ jobs:
           icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: scan-hardened-s3-resource-simple-staging-image
-  old_name: scan-ecr-harden-s3-resource-simple-staging
   plan:
   - in_parallel:
     - get: image-tags-harden-s3-resource-simple-staging
@@ -698,7 +684,6 @@ jobs:
           icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: scan-hardened-s3-resource-simple-image
-  old_name: scan-ecr-harden-s3-resource-simple
   plan:
   - in_parallel:
     - get: image-tags-harden-s3-resource-simple

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -902,20 +902,15 @@ jobs:
     - get: ecr-hardened-s3-resource-simple-staging-repo
       params:
         format: oci
-  - task: build-staging
-    privileged: true
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: concourse/oci-build-task
-      inputs:
-      - name: ecr-hardened-s3-resource-simple-staging-repo
-      outputs:
-      - name: image
-      run:
-        path: build
+    - get: hardened-concourse-image-prod-version
+      params: {bump: patch}
+  - put: ecr-harden-concourse-task-prod-repo
+    params:
+      image: ecr-hardened-s3-resource-simple-staging-repo/image.tar
+      additional_tags: hardened-concourse-image-prod-version/version
+  - put: hardened-concourse-image-prod-version
+    params: {file: hardened-concourse-image-prod-version/version}
+
 
 resources:
 - name: pipeline-source

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -40,37 +40,6 @@ jobs:
       subject_text: "Audit Results for latest harden-concourse-task-staging image - Failure"
       body_text: "The pipeline to audit the latest harden-concourse-task-staging image has failed! Please check me out *wink*"
 
-- name: audit-hardened-concourse-task-image
-  old_name: audit-harden-concourse-task
-  plan:
-  - in_parallel: &common_resources
-    - get: monthly
-      trigger: true
-    - get: scan-source
-      trigger: false
-  - get: image-source
-    params:
-      format: oci
-    resource: ecr-harden-concourse-task-repo
-  - load_var: latest-tag
-    file: image-source/tag
-  - task: audit
-    file: scan-source/ci/audit-ecr-container.yml
-    vars:
-      image: harden-concourse-task
-      tag: ((.:latest-tag))
-  on_success:
-    put: send-an-email
-    params:
-      subject_text: "Audit Results for latest harden-concourse-task image"
-      body_text: "Here are the audit results for the latest harden-concourse-task"
-      attachment_globs: ["audit/cis-audit.html"]
-  on_failure:
-    put: send-an-email
-    params:
-      subject_text: "Audit Results for latest harden-concourse-task image - Failure"
-      body_text: "The pipeline to audit the latest harden-concourse-task image has failed! Please check me out *wink*"
-
 - name: audit-hardened-s3-resource-simple-staging-image
   old_name: audit-harden-s3-resource-simple-staging
   plan:
@@ -97,33 +66,6 @@ jobs:
     params:
       subject_text: "Audit Results for the latest harden-s3-resource-simple-staging image - Failure"
       body_text: "The pipeline to audit the latest harden-s3-resource-simple-staging image has failed! Please check me out *wink*"
-
-- name: audit-hardened-s3-resource-simple-image
-  old_name: audit-harden-s3-resource-simple
-  plan:
-  - in_parallel: *common_resources
-  - get: image-source
-    params:
-      format: oci
-    resource: ecr-harden-s3-resource-simple-repo
-  - load_var: latest-tag
-    file: image-source/tag
-  - task: audit
-    file: scan-source/ci/audit-ecr-container.yml
-    vars:
-      image: harden-s3-resource-simple
-      tag: ((.:latest-tag))
-  on_success:
-    put: send-an-email
-    params:
-      subject_text: "Audit Results for latest harden-s3-resource-simple image"
-      body_text: "Here are the audit results for the latest harden-s3-resource-simple image"
-      attachment_globs: ["audit/cis-audit.html"]
-  on_failure:
-    put: send-an-email
-    params:
-      subject_text: "Audit Results for harden-s3-resource-simple image - Failure"
-      body_text: "The pipeline to audit the harden-s3-resource-simple image has failed! Please check me out *wink*"
 
 - name: conmon-hardened-concourse-task-image
   old_name: conmon-harden-concourse-task
@@ -812,7 +754,7 @@ jobs:
       params:
         format: oci
       resource: ecr-hardened-concourse-task-staging-repo
-      passed: [scan-latest-hardened-concourse-task-staging-image]
+      passed: [scan-latest-hardened-concourse-task-staging-image, audit-hardened-concourse-task-staging-image]
       trigger: true
     - get: hardened-concourse-task-image-prod-version
       params: {bump: patch}
@@ -831,7 +773,7 @@ jobs:
       params:
         format: oci
       resource: ecr-hardened-s3-resource-simple-staging-repo
-      passed: [scan-latest-hardened-s3-resource-simple-staging-image]
+      passed: [scan-latest-hardened-s3-resource-simple-staging-image, audit-hardened-s3-resource-simple-staging-image]
       trigger: true
     - get: hardened-s3-resource-simple-image-prod-version
       params: {bump: patch}
@@ -1082,8 +1024,6 @@ groups:
 - name: all
   jobs:
   - configure-pipeline
-  - audit-hardened-concourse-task-image
-  - audit-hardened-s3-resource-simple-image
   - audit-hardened-concourse-task-staging-image
   - audit-hardened-s3-resource-simple-staging-image
   - conmon-hardened-concourse-task-image
@@ -1146,5 +1086,5 @@ groups:
   - terraform-apply-ecr
 - name: audit
   jobs:
-  - audit-hardened-concourse-task-image
-  - audit-hardened-s3-resource-simple-image
+  - audit-hardened-concourse-task-staging-image
+  - audit-hardened-s3-resource-simple-staging-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -251,51 +251,6 @@ jobs:
         username: ((username))
         icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
-- name: scan-latest-hardened-concourse-task-image
-  old_name: scan-latest-harden-concourse-task-image
-  plan:
-  - in_parallel:
-    - get: weekly
-      trigger: true
-    - get: scan-source
-      trigger: false
-    - get: ecr-harden-concourse-task-repo
-      params:
-        format: oci
-      trigger: true
-  - load_var: tag
-    file: ecr-harden-concourse-task-repo/tag
-  - task: scan
-    file: scan-source/ci/scan-ecr-container.yml
-    params:
-      IMAGE: "((harden-concourse-task-repo)):((.:tag))"
-      AWS_DEFAULT_REGION: us-gov-west-1
-      REGISTRY: ((aws-ecr-registry))
-  - task: check
-    file: scan-source/ci/ecr-cve-check.yml
-    params:
-      IMAGE: "((harden-concourse-task-repo)):((.:tag))"
-      IMAGENAME: "harden-concourse-task:((.:tag))"
-    on_failure:
-      put: slack
-      params:
-        text:  |
-          :x: FAILED harden-concourse-task CVE check
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: '#cg-platform-news'
-        username: ((username))
-        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
-    on_success:
-      put: slack
-      params:
-        text_file: message/alert.txt
-        text: |
-          $TEXT_FILE_CONTENT
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: '#cg-platform-news'
-        username: ((username))
-        icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
-
 - name: scan-latest-hardened-s3-resource-simple-staging-image
   old_name: scan-latest-harden-s3-resource-simple-image-staging
   plan:
@@ -551,7 +506,7 @@ jobs:
   plan:
   - in_parallel:
     - get: scan-source
-      passed: [scan-latest-hardened-concourse-task-image]
+      passed: [upload-hardened-concourse-task-prod-image]
     - get: weekly
       trigger: true
     - get: ecr-harden-concourse-task-repo
@@ -894,7 +849,7 @@ jobs:
           username: ((username))
           icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
-- name: upload-hardened-concourse-prod-image
+- name: upload-hardened-concourse-task-prod-image
   plan:
   - get: scan-source
     passed: [scan-latest-hardened-concourse-task-staging-image]
@@ -1166,7 +1121,6 @@ groups:
   - scan-latest-hardened-s3-resource-simple-staging-image
   - scan-hardened-concourse-task-image
   - scan-hardened-s3-resource-simple-image
-  - scan-latest-hardened-concourse-task-image
   - scan-latest-hardened-s3-resource-simple-image
   - upload-hardened-concourse-prod-image
 - name: docker-scan
@@ -1192,7 +1146,7 @@ groups:
   - conmon-18fgsa-sql-clients-image
 - name: hardened-scan
   jobs:
-  - scan-latest-hardened-concourse-task-image
+  - scan-latest-hardened-concourse-task-staging-image
   - scan-latest-hardened-s3-resource-simple-image
   - list-tags-hardened-concourse-task
   - list-tags-hardened-s3-resource-simple

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1143,11 +1143,11 @@ resource_types:
   type: semver
   source:
     driver: s3
-    bucket: {{semver-bucket}}
+    bucket: ((semver-bucket))
     key: harden-concourse-docker-image-version
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    region_name: {{aws-region}}
+    access_key_id: ((aws-access-key-id))
+    secret_access_key: ((aws-secret-access-key))
+    region_name: ((aws-region))
     initial_version: 1.0.0
 
 groups:


### PR DESCRIPTION
## Changes proposed in this pull request:

- This adds gating on CVEs from staging to production
- Creates job to upload image to production, and adds conditional code to only run this job if passing CVE and Audit checks
- Removes Audit jobs for production images, since we should only need to Audit staging images
- Fixes some naming conventions
- Fixes delete script

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding the gating on CVEs will help us towards our container scanning compliance
