### PR TITLE
update conmon scan to use template file and output as csv

### DIFF
--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -20,5 +20,4 @@ printf "${CONFIG}" > ~/.docker/config.json
 TAG=$(cat image-source/tag)
 
 #scan
-grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o cyclonedx --file output/${FILE}.xml
-
+grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o template -t templates/conmon_csv.tmpl --file output/${FILE}.csv

--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -20,4 +20,4 @@ printf "${CONFIG}" > ~/.docker/config.json
 TAG=$(cat image-source/tag)
 
 #scan
-grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o template -t templates/conmon_csv.tmpl --file output/${FILE}.csv
+grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o template -t scan-source/templates/conmon_csv.tmpl --file output/${FILE}.csv

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -801,7 +801,8 @@ resources:
             "ci/audit-ecr-container.yml",
             "ci/ecr-cve-check.sh",
             "ci/ecr-cve-check.yml",
-            "ci/grype.yml"]
+            "ci/grype.yml",
+            "templates/conmon_csv.tmpl"]
     commit_verification_keys: ((cloud-gov-pgp-keys))      
 
 - name: terraform-config

--- a/templates/conmon_csv.tmpl
+++ b/templates/conmon_csv.tmpl
@@ -1,0 +1,4 @@
+"Vulnerability ID","Description","Package","Version Installed","Severity","Fix State","Fix Versions"
+{{- range .Matches}}
+"{{.Vulnerability.ID}}","{{.Vulnerability.Description}}","{{.Artifact.Name}}","{{.Artifact.Version}}","{{.Vulnerability.Severity}}","{{.Vulnerability.Fix.State}}","{{.Vulnerability.Fix.Versions}}"
+{{- end}}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds template to be used by grype for conmon scan

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, updates the grype output to be easier to work with
