### PR TITLE
Use latest container

### DIFF
--- a/ci/audit-ecr-container.yml
+++ b/ci/audit-ecr-container.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: ((image))
     aws_region: us-gov-west-1
-    tag: ((tag))
+    semver_constraint: ">= 1.0.0"
 
 params:
   IMAGE: ((image))

--- a/ci/conmon-scan-ecr-container.yml
+++ b/ci/conmon-scan-ecr-container.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs: 
 - name: scan-source

--- a/ci/cve-check.yml
+++ b/ci/cve-check.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs:
 - name: scan-source

--- a/ci/delete-image.yml
+++ b/ci/delete-image.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs:
   - name: scan-source

--- a/ci/ecr-cve-check.yml
+++ b/ci/ecr-cve-check.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs:
 - name: scan-source

--- a/ci/list-images.yml
+++ b/ci/list-images.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs:
   - name: scan-source

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,8 +20,6 @@ jobs:
     params:
       format: oci
     resource: ecr-hardened-concourse-task-staging-repo
-  - load_var: latest-tag
-    file: image-source/tag
   - task: audit
     file: scan-source/ci/audit-ecr-container.yml
     vars:
@@ -46,8 +44,6 @@ jobs:
     params:
       format: oci
     resource: ecr-hardened-s3-resource-simple-staging-repo
-  - load_var: latest-tag
-    file: image-source/tag
   - task: audit
     file: scan-source/ci/audit-ecr-container.yml
     vars:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -26,7 +26,6 @@ jobs:
     file: scan-source/ci/audit-ecr-container.yml
     vars:
       image: harden-concourse-task-staging
-      tag: ((.:latest-tag))
   on_success:
     put: send-an-email
     params:
@@ -53,7 +52,6 @@ jobs:
     file: scan-source/ci/audit-ecr-container.yml
     vars:
       image: harden-s3-resource-simple-staging
-      tag: ((.:latest-tag))
   on_success:
     put: send-an-email
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -774,7 +774,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: use-latest-container
+    branch: main
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -782,7 +782,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: use-latest-container
+    branch: main
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -809,7 +809,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: use-latest-container
+    branch: main
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -774,7 +774,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: use-latest-container
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -782,7 +782,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: use-latest-container
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -809,7 +809,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: use-latest-container
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/scan-container.yml
+++ b/ci/scan-container.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs: 
 - name: scan-source

--- a/ci/scan-ecr-container-no-ignore.yml
+++ b/ci/scan-ecr-container-no-ignore.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs: 
 - name: scan-source

--- a/ci/scan-ecr-container.yml
+++ b/ci/scan-ecr-container.yml
@@ -8,7 +8,7 @@ image_resource:
     aws_secret_access_key: ((aws-secret))
     repository: harden-concourse-task
     aws_region: us-gov-west-1
-    tag: ((harden-concourse-task-tag))
+    semver_constraint: ">= 1.0.0"
 
 inputs: 
 - name: scan-source


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates pipeline so that instead of specifying a specific tag it will always grab the latest image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using the latest container will keep us up to date with security fixes
