### PR TITLE
set xml report output to same directory as html report

### DIFF
--- a/ci/audit-ecr-container.sh
+++ b/ci/audit-ecr-container.sh
@@ -10,7 +10,7 @@ pip3 install beautifulsoup4
 
 # Run cis audit and put html results into cis-audit.html file
 echo "running audit"
-usg audit cis_level1_server --html-file audit/cis-audit.html
+usg audit cis_level1_server --html-file audit/cis-audit.html --results-file audit/cis-audit.xml
 
 # Parse the resulting cis-audit.html file looking for pass/fail via a python script
 if [ "$(./scan-source/ci/parse_cis_audit_html.py --inputfile audit/cis-audit.html)" == "failed" ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Save xml report and html report to the same directory so that they may be deleted easily in the future.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Deletion of these files will be necessary when we are running the audit before creating the image. Since we are currently running the audit after the image is created, it is not saved to the image. I will be creating a ticket for this task.