### PR TITLE
add slack notifications for audit jobs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -30,13 +30,29 @@ jobs:
       subject_text: "Passed - Audit for the latest harden-concourse-task-staging image"
       body_text: "The audit for the latest harden-concourse-task-staging image passed successfully. Results are attached."
       attachment_globs: ["audit/cis-audit.html"]
+    put: slack
+    params:
+      text:  |
+        :white_check_mark: PASSED - Audit for the latest latest harden-concourse-task-staging image successful
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
   on_failure:
     put: send-an-email
     params:
-      subject_text: "Failed - Audit for latest harden-concourse-task-staging image"
+      subject_text: "Failed - Audit for the latest harden-concourse-task-staging image"
       body_text: "The audit for the latest harden-concourse-task-staging image contains failures. Results are attached."
       attachment_globs: ["audit/cis-audit.html"]
-
+    put: slack
+    params:
+      text:  |
+        :x: FAILED - Audit for the latest harden-concourse-task-staging image has failed tasks
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
+    
 - name: audit-hardened-s3-resource-simple-staging-image
   plan:
   - in_parallel: *common_resources
@@ -54,12 +70,28 @@ jobs:
       subject_text: "Passed - Audit for the harden-s3-resource-simple-staging image"
       body_text: "The audit for the latest harden-s3-resource-simple-staging image passed successfully. Results are attached."
       attachment_globs: ["audit/cis-audit.html"]
+    put: slack
+    params:
+      text:  |
+        :white_check_mark: PASSED - Audit for the latest latest harden-s3-resource-simple-staging image successful
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
   on_failure:
     put: send-an-email
     params:
-      subject_text: "Failed - Audit for latest harden-s3-resource-simple-staging image"
+      subject_text: "Failed - Audit for the latest harden-s3-resource-simple-staging image"
       body_text: "The audit for the latest harden-s3-resource-simple-staging image contains failures. Results are attached."
       attachment_globs: ["audit/cis-audit.html"]
+    put: slack
+    params:
+      text:  |
+        :x: FAILED - Audit for the latest harden-s3-resource-simple-staging image has failed tasks
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: '#cg-platform-news'
+      username: ((username))
+      icon_url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40
 
 - name: conmon-hardened-concourse-task-image
   plan:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Also sends notifications to slack on audit success/failure

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Helps meet container scanning requirements by alerting us when we have successful or failed audits of our images.
