### PR TITLE
create blank xml file in advanced to avoid errors writing to the file

### DIFF
--- a/ci/audit-ecr-container.sh
+++ b/ci/audit-ecr-container.sh
@@ -3,6 +3,7 @@
 # set up dir and file
 mkdir audit
 touch audit/cis-audit.html
+touch audit/cis-audit.xml
 
 echo "installing bs4"
 # Install the python library BeautifulSoup to parse html 


### PR DESCRIPTION
## Changes proposed in this pull request:

- This creates a blank cis-audit.xml file in advance to avoid errors writing to the file, like what's done for the .html file

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, fixes an error writing to the audit.xml file