### PR TITLE
use PWD so that usg can write the result files correctly

### DIFF
--- a/ci/audit-ecr-container.sh
+++ b/ci/audit-ecr-container.sh
@@ -11,7 +11,7 @@ pip3 install beautifulsoup4
 
 # Run cis audit and put html results into cis-audit.html file
 echo "running audit"
-usg audit cis_level1_server --html-file audit/cis-audit.html --results-file audit/cis-audit.xml
+usg audit cis_level1_server --html-file $PWD/audit/cis-audit.html --results-file $PWD/audit/cis-audit.xml
 
 # Parse the resulting cis-audit.html file looking for pass/fail via a python script
 if [ "$(./scan-source/ci/parse_cis_audit_html.py --inputfile audit/cis-audit.html)" == "failed" ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- specify PWD so that the result files can be written to correctly

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, fixing errors
