### PR TITLE
add cve to ignore list

### DIFF
--- a/ci/grype.yaml
+++ b/ci/grype.yaml
@@ -1,6 +1,7 @@
 #Grype ignore configurations.
 
 ignore:
-  - vulnerability: CVE-2007-4642  #false positive, alerting on package of same name
-  - vulnerability: CVE-2007-4644  #false positive, alerting on package of same name
-  - vulnerability: CVE-2018-20225 #disputed as intended functionality
+  - vulnerability: CVE-2007-4642   #false positive, alerting on package of same name
+  - vulnerability: CVE-2007-4644   #false positive, alerting on package of same name
+  - vulnerability: CVE-2018-20225  #disputed as intended functionality
+  - vulnerability: CVE-2018-9057   #false positive as outlined here: https://github.com/anchore/grype/issues/1377


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds CVE to ignore list since it is a false positive

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Keeping this file updated makes sure that our scans can pass, and that we are keeping track of why the CVEs are ignored
