### PR TITLE
Fix conmon scans

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -140,7 +140,7 @@ jobs:
     image: ecr-harden-concourse-task-repo
     params:
       FILE: s3-resource-simple
-      IMAGE: "((harden-s3-resource-simple-repo))"
+      IMAGE: ((harden-s3-resource-simple-repo))
       AWS_DEFAULT_REGION: us-gov-west-1
       REGISTRY: ((aws-ecr-registry))
   on_success:
@@ -148,7 +148,7 @@ jobs:
     params:
       subject_text: "ConMon Results for harden-s3-resource-simple image scans"
       body_text: "Here is the conmon results for s3-resource-simple"
-      attachment_globs: ["output/s3-resource-simple.xml"]
+      attachment_globs: ["output/s3-resource-simple.csv"]
   on_failure:
     put: send-an-email
     params:
@@ -167,7 +167,7 @@ jobs:
     image: ecr-harden-concourse-task-repo
     params:
       FILE: sql-clients
-      IMAGE: "((sql-clients-repo))"
+      IMAGE: ((sql-clients-repo))
       AWS_DEFAULT_REGION: us-gov-west-1
       REGISTRY: ((aws-ecr-registry))
   on_success:
@@ -175,7 +175,7 @@ jobs:
     params:
       subject_text: "ConMon Results for sql-clients image scans"
       body_text: "Here is the conmon results for sql-clients"
-      attachment_globs: ["output/sql-clients.xml"]
+      attachment_globs: ["output/sql-clients.csv"]
   on_failure:
     put: send-an-email
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -121,7 +121,7 @@ jobs:
     params:
       subject_text: "ConMon Results for harden-concourse-task image scans"
       body_text: "Here is the conmon results for harden-concourse-task"
-      attachment_globs: ["output/concourse-task.xml"]
+      attachment_globs: ["output/concourse-task.csv"]
   on_failure:
     put: send-an-email
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -113,7 +113,7 @@ jobs:
     image: ecr-harden-concourse-task-repo
     params:
       FILE: concourse-task
-      IMAGE: "((harden-concourse-task-repo))"
+      IMAGE: ((harden-concourse-task-repo))
       AWS_DEFAULT_REGION: us-gov-west-1
       REGISTRY: ((aws-ecr-registry))
   on_success:
@@ -865,7 +865,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: fix-conmon
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -873,7 +873,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: fix-conmon
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -900,7 +900,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: main
+    branch: fix-conmon
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -865,7 +865,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: fix-conmon
+    branch: main
     paths: [ci/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
@@ -873,7 +873,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: fix-conmon
+    branch: main
     paths: ["ci/scan-container.sh",
             "ci/scan-container.yml",
             "ci/scan-ecr-container.sh",
@@ -900,7 +900,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/container-scanning
-    branch: fix-conmon
+    branch: main
     paths: [terraform/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes conmon scan jobs to reference csv file rather than xml
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing file type
