### PR TITLE
Add two new repositories and make list easier to scan

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -6,7 +6,20 @@ variable "tooling_stack_name" {
 
 variable "repositories" {
   type = list(string)
-  default = ["concourse-task","s3-resource-simple","oracle-client","sql-clients","harden-concourse-task","harden-s3-resource-simple","harden-concourse-task-staging","harden-s3-resource-simple-staging"]
+  default = [
+    "concourse-task",
+    "git-resource",
+    "harden-concourse-task",
+    "harden-concourse-task-staging",
+    "harden-s3-resource-simple",
+    "harden-s3-resource-simple-staging",
+    "oracle-client",
+    "registry-image-resource",
+    "s3-resource-simple",
+    "s3-simple-resource",
+    "sql-clients",
+    "ubuntu-hardened",
+  ]
 }
 
 terraform {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Split to lines and order alphabetically
- I created another repository manually in the console, which I shouldn't have done. I'll do another PR to see if we can make Terraform adopt it.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Expanding existing pattern of use.
