### PR TITLE
Restore original order, since resources are named by index

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -8,16 +8,16 @@ variable "repositories" {
   type = list(string)
   default = [
     "concourse-task",
+    "s3-resource-simple",
+    "oracle-client",
+    "sql-clients",
     "git-resource",
     "harden-concourse-task",
-    "harden-concourse-task-staging",
     "harden-s3-resource-simple",
+    "harden-concourse-task-staging",
     "harden-s3-resource-simple-staging",
-    "oracle-client",
     "registry-image-resource",
-    "s3-resource-simple",
     "s3-simple-resource",
-    "sql-clients",
     "ubuntu-hardened",
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Because resources are named by index, terraform interpreted the reordering as a renaming and tried to destroy/recreate most repositories
- This PR reverts the order for now; will follow up to try to rename the resources to use the repository names to allow order independence

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Refactor.
