### PR TITLE
Fix the order of image repositories -- missed git-resource last time

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -11,7 +11,6 @@ variable "repositories" {
     "s3-resource-simple",
     "oracle-client",
     "sql-clients",
-    "git-resource",
     "harden-concourse-task",
     "harden-s3-resource-simple",
     "harden-concourse-task-staging",
@@ -19,6 +18,7 @@ variable "repositories" {
     "registry-image-resource",
     "s3-simple-resource",
     "ubuntu-hardened",
+    "git-resource",
   ]
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title and previous commit

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
