### PR TITLE
Attempt switching to for_each for order independent resource creation

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -5,20 +5,20 @@ variable "tooling_stack_name" {
 }
 
 variable "repositories" {
-  type = list(string)
+  type = set(string)
   default = [
     "concourse-task",
-    "s3-resource-simple",
-    "oracle-client",
-    "sql-clients",
-    "harden-concourse-task",
-    "harden-s3-resource-simple",
-    "harden-concourse-task-staging",
-    "harden-s3-resource-simple-staging",
-    "registry-image-resource",
-    "s3-simple-resource",
-    "ubuntu-hardened",
     "git-resource",
+    "harden-concourse-task",
+    "harden-concourse-task-staging",
+    "harden-s3-resource-simple",
+    "harden-s3-resource-simple-staging",
+    "oracle-client",
+    "registry-image-resource",
+    "s3-resource-simple",
+    "s3-simple-resource",
+    "sql-clients",
+    "ubuntu-hardened",
   ]
 }
 
@@ -38,8 +38,8 @@ data "terraform_remote_state" "tooling" {
 
 
 resource "aws_ecr_repository" "repository" {
-  count = length(var.repositories)
+  for_each = var.repositories
 
-  name                 = var.repositories[count.index]
+  name                 = each.key
   image_tag_mutability = "IMMUTABLE"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- See https://developer.hashicorp.com/terraform/language/meta-arguments/for_each#basic-syntax
- Thanks to @markdboyd 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
