### PR TITLE
add cf resource repo

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -7,6 +7,7 @@ variable "tooling_stack_name" {
 variable "repositories" {
   type = set(string)
   default = [
+    "cf-resource",
     "concourse-task",
     "general-task",
     "git-resource",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Creates an ECR repo for the cf-resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just creating a repo for our hardened cf-resource image
