### PR TITLE
Add github-pr-resource

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -11,6 +11,7 @@ variable "repositories" {
     "concourse-task",
     "general-task",
     "git-resource",
+    "github-pr-resource",
     "harden-concourse-task",
     "harden-concourse-task-staging",
     "harden-s3-resource-simple",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds github-pr-resource to list of repos that should be created in ECR

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, this just updates terraform to create an ECR repo for the github-pr-resource
