### PR TITLE
ConMon requires XML-formatted reports but HTML is more human-readable

### DIFF
--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -21,4 +21,6 @@ TAG=$(cat image-source/tag)
 
 #scan
 grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o template -t scan-source/templates/conmon_csv.tmpl --file output/${FILE}.csv
+# The JAB requires XML formatted reports so they can be uploaded to
+# their vulnerability management tool.
 grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o cyclonedx --file output/${FILE}.xml

--- a/ci/conmon-scan-ecr-container.sh
+++ b/ci/conmon-scan-ecr-container.sh
@@ -21,3 +21,4 @@ TAG=$(cat image-source/tag)
 
 #scan
 grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o template -t scan-source/templates/conmon_csv.tmpl --file output/${FILE}.csv
+grype ${IMAGE}:${TAG} -c scan-source/ci/grype.yaml -q -o cyclonedx --file output/${FILE}.xml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -121,7 +121,9 @@ jobs:
     params:
       subject_text: "ConMon Results for harden-concourse-task image scans"
       body_text: "Here is the conmon results for harden-concourse-task"
-      attachment_globs: ["output/concourse-task.csv"]
+      attachment_globs:
+        - "output/concourse-task.html"
+        - "output/concourse-task.xml"
   on_failure:
     put: send-an-email
     params:
@@ -148,7 +150,9 @@ jobs:
     params:
       subject_text: "ConMon Results for harden-s3-resource-simple image scans"
       body_text: "Here is the conmon results for s3-resource-simple"
-      attachment_globs: ["output/s3-resource-simple.csv"]
+      attachment_globs:
+        - "output/s3-resource-simple.html"
+        - "output/s3-resource-simple.xml"
   on_failure:
     put: send-an-email
     params:
@@ -175,7 +179,9 @@ jobs:
     params:
       subject_text: "ConMon Results for sql-clients image scans"
       body_text: "Here is the conmon results for sql-clients"
-      attachment_globs: ["output/sql-clients.csv"]
+      attachment_globs:
+        - "output/sql-clients.html"
+        - "output/sql-clients.xml"
   on_failure:
     put: send-an-email
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -122,7 +122,7 @@ jobs:
       subject_text: "ConMon Results for harden-concourse-task image scans"
       body_text: "Here is the conmon results for harden-concourse-task"
       attachment_globs:
-        - "output/concourse-task.html"
+        - "output/concourse-task.csv"
         - "output/concourse-task.xml"
   on_failure:
     put: send-an-email
@@ -151,7 +151,7 @@ jobs:
       subject_text: "ConMon Results for harden-s3-resource-simple image scans"
       body_text: "Here is the conmon results for s3-resource-simple"
       attachment_globs:
-        - "output/s3-resource-simple.html"
+        - "output/s3-resource-simple.csv"
         - "output/s3-resource-simple.xml"
   on_failure:
     put: send-an-email
@@ -180,7 +180,7 @@ jobs:
       subject_text: "ConMon Results for sql-clients image scans"
       body_text: "Here is the conmon results for sql-clients"
       attachment_globs:
-        - "output/sql-clients.html"
+        - "output/sql-clients.csv"
         - "output/sql-clients.xml"
   on_failure:
     put: send-an-email


### PR DESCRIPTION
## Changes proposed in this pull request:

- Restore XML-formatted reports, which are required by our ConMon processing team
- Reviewer discussion: https://groups.google.com/a/gsa.gov/g/cloud-gov-compliance/c/OhxaJrJPcwM
- Team discussion: https://gsa-tts.slack.com/archives/C04UFEJF413/p1693508451785299

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.