### PR TITLE
Set tags_all

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -52,4 +52,5 @@ resource "aws_ecr_repository" "repository" {
   name                 = each.key
   image_tag_mutability = "MUTABLE"
   tags                 = {}
+  tags_all             = {}
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Set tags_all to empty brackets so that plugin doesn't error on null value

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just a pipeline fix