### PR TITLE
remove unused pipeline-tasks resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -736,13 +736,6 @@ resources:
             "ci/ecr-cve-check.yml",
             "ci/grype.yml",
             "templates/conmon_csv.tmpl"]
-    commit_verification_keys: ((cloud-gov-pgp-keys))      
-
-- name: pipeline-tasks
-  type: git
-  source:
-    uri: https://github.com/cloud-gov/cg-pipeline-tasks.git
-    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: sql-clients-docker-repo


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove pipeline-tasks resource as it is no longer used in any jobs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing unused items
